### PR TITLE
fix requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ eventlet
 python-socketio[client]
 cachetools
 sqlitedict
-unicorn-binance-websocket-api
+unicorn-binance-websocket-api==1.34.1
 unicorn-fy
 xmltodict
 diskcache


### PR DESCRIPTION
unicorn-binance-websocket-api can't install newest version, change to older =1.34.1